### PR TITLE
config file is never applied with pip install

### DIFF
--- a/jncep/jncep.py
+++ b/jncep/jncep.py
@@ -29,6 +29,12 @@ console = getConsole()
 )
 def main(is_debug):
     setup_logging(is_debug)
+    try:
+        apply_options_from_config()
+    except Exception:
+        console.warning(
+            "There was an error reading the configuration at: "
+            f"{DEFAULT_CONFIG_FILEPATH}. Continuing..." )
 
 
 main.add_command(generate_epub)
@@ -37,11 +43,4 @@ main.add_command(update_tracked)
 main.add_command(config_manage)
 
 if __name__ == "__main__":
-    try:
-        apply_options_from_config()
-    except Exception:
-        console.warning(
-            "There was an error reading the configuration at: "
-            f"{DEFAULT_CONFIG_FILEPATH}. Continuing..."
-        )
     main()


### PR DESCRIPTION
In case of a windows pip install, python creates a jncep.exe with this content:
```
# -*- coding: utf-8 -*-
import re
import sys
from jncep.jncep import main
if __name__ == '__main__':
    sys.argv[0] = re.sub(r'(-script\.pyw|\.exe)?$', '', sys.argv[0])
    sys.exit(main())
```

that calls the main() function directly thus apply_options_from_config is never called.
moving it into main fixes the issue and make the config file work again.