### PR TITLE
Add support for https://jnc-nina.eu

### DIFF
--- a/jncep/jnclabs.py
+++ b/jncep/jnclabs.py
@@ -12,10 +12,10 @@ from .utils import deep_freeze
 logger = logging.getLogger(__name__)
 console = utils.getConsole()
 
-CDN_IMG_URL_BASE = "https://d2dq7ifhe7bu0f.cloudfront.net"
+CDN_IMG_URL_BASE = "https://cdn.jnc-nina.eu"
 
-LABS_API_URL_BASE = "https://labs.j-novel.club"
-LABS_API_PATH_BASE = "/app/v1"
+LABS_API_URL_BASE = "https://api.jnc-nina.eu"
+LABS_API_PATH_BASE = "/app/v2alpha"
 LABS_API_COMMON_PARAMS = {"format": "json"}
 LABS_API_COMMON_HEADERS = {
     "accept": "application/json",

--- a/jncep/jncweb.py
+++ b/jncep/jncweb.py
@@ -6,7 +6,7 @@ import attr
 
 logger = logging.getLogger(__name__)
 
-JNC_URL_BASE = "https://j-novel.club"
+JNC_URL_BASE = "https://jnc-nina.eu/"
 
 RESOURCE_TYPE_SERIES = "SERIES"
 RESOURCE_TYPE_VOLUME = "VOLUME"
@@ -48,8 +48,8 @@ def resource_from_url(url):
         # new site
         # new site changed titles to series in URL
         # so process both
-        s_re = r"^/(?:series|titles)/(.+?)(?:(?=/)|$)"
-        c_re = r"^/read/(.+?)(?:(?=/)|$)"
+        s_re = r"^.*?/(?:series|titles)/(.+?)(?:(?=/)|$)"
+        c_re = r"^.*?/read/(.+?)(?:(?=/)|$)"
         v_re = r"^volume-(\d+)$"
 
         m = re.match(s_re, pu.path)

--- a/jncep/track.py
+++ b/jncep/track.py
@@ -209,7 +209,7 @@ async def sync_series_backward(session, follows, tracked_series, is_delete):
 
         async def do_undollow(jnc_resource):
             # use the follow_raw_data: to avoid another call to the API
-            series_id = jnc_resource.follow_raw_data.legacyId
+            series_id = jnc_resource.follow_raw_data.id
             title = jnc_resource.follow_raw_data.title
             console.warning(f"Unfollow '{title}'...")
             await session.api.unfollow_series(series_id)

--- a/jncep/update.py
+++ b/jncep/update.py
@@ -344,7 +344,7 @@ def _verify_series_needs_update_check(event_feed, series_details):
         if "details" in event and event.details.startswith("Release of Part"):
             # no s in JNC attr
             series = event.serie
-            if series.legacyId != series_id:
+            if series.id != series_id:
                 continue
 
             launch_date = dateutil.parser.parse(event.launch)


### PR DESCRIPTION
Hello @gvellut 

The PR would normally fix https://github.com/gvellut/jncep/issues/47 but it cannot be merged because it is incompatible with https://j-novel.club

As explained in the issue, I think that having another `jnclabs` and `jncweb` for https://jnc-nina.eu will be the best way, but managing the code of the session seems difficult on my side.

Globally, the changes are the next ones:

- `legacyId` is always empty, so I replace it by `id`
- `part_id` is replaced with `id`
- checking the launch information to only process parts that are available
- change `API` and `URL`
- jnc-nina supports French and German, but in French there is a `/fr/` before the `series` and `read` part. That's why the regex are adapted

I didn't make a complete test, but it looks like it is working as expected.