### PR TITLE
Feature/otp authentication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ pytest.ini
 /test_output
 /test_input
 /output_*
+/ai_output

--- a/README.md
+++ b/README.md
@@ -53,12 +53,20 @@ The `jncep` tool must be launched on the command-line. It has 4 commands:
 
 ## J-Novel Club account credentials
 
-All the commands need some user credentials (email and password) in order to communicate with the J-Novel Club API. They are the same values as the ones used to log in to the J-Novel Club website with a browser.
+All the commands need some user credentials in order to communicate with the J-Novel Club API. You can authenticate using either:
+- **Password authentication**: Email and password (same values as used to log in to the J-Novel Club website)
+- **OTP authentication**: Email and OTP code (One-Time Password, JNC Main only)
 
-Those credentials can be passed directly on the command line using the `--email` and `--password` arguments to the __command__ (or subcommand for `track`), not the `jncep` tool directly. For example, using the `epub` command:
+Those credentials can be passed directly on the command line using the `--email` and `--password` arguments (or `--otp` for OTP) to the __command__ (or subcommand for `track`), not the `jncep` tool directly. For example, using the `epub` command with password:
 
 ```console
 jncep epub --email user@example.com --password "foo%bar666!" https://j-novel.club/series/tearmoon-empire
+```
+
+Or with OTP:
+
+```console
+jncep epub --email user@example.com --otp https://j-novel.club/series/tearmoon-empire
 ```
 
 ### Passing the credentials indirectly
@@ -97,6 +105,13 @@ export JNCEP_EMAIL=user@example.com
 export JNCEP_PASSWORD="foo%bar666!"
 ```
 
+Or to use OTP authentication:
+
+```console
+export JNCEP_EMAIL=user@example.com
+export JNCEP_USE_OTP=true
+```
+
 Then, the same command as above can be simply launched as follows:
 
 ```console
@@ -104,6 +119,27 @@ jncep epub https://j-novel.club/series/tearmoon-empire
 ```
 
 See the [general documentation on environment variables](#environment-variables-1).
+
+### OTP (One-Time Password) authentication
+
+OTP authentication is available as an alternative to password authentication for JNC Main (not available for JNC Nina). When using OTP:
+
+1. Use the `--otp` flag instead of `--password`
+2. The tool will generate an OTP code and display it
+3. Visit https://j-novel.club/user/otp in your browser and enter the displayed code
+4. The CLI will automatically detect when you've verified the code and complete the login
+
+**Note:** OTP authentication requires interactive use - the CLI will wait (block) until you complete verification on the website. This is not suitable for fully automated scripts. For automation, use password authentication instead.
+
+**Example:**
+
+```console
+jncep epub --email user@example.com --otp https://j-novel.club/series/tearmoon-empire
+```
+
+The OTP code will be displayed, and you'll need to enter it on the website. The CLI will poll for verification automatically.
+
+You can also set `USE_OTP = true` in the configuration file or use the `JNCEP_USE_OTP` environment variable to enable OTP mode by default.
 
 ### JNC Nina account credentials
 
@@ -115,6 +151,8 @@ Starting with version 50, some support for [JNC Nina](https://jnc-nina.eu/) (J-N
 - JNC Nina password:  `-pn` / `--password-nina`, config option: `PASSWORD_NINA`
 
 If the JNC Nina email is the same as the J-Novel Club email, it is possible to only use the main `--email` option (so no need to repeat). The JNC Nina password is not optional though.
+
+**Note:** OTP authentication is not available for JNC Nina - only password authentication is supported.
 
 One of the 2 options (for the main J-Novel Club website or for the JNC Nina website) must be present. For the `epub` or `update` commands, the choice of which credential to use is made depending on the series URL. When using `track sync`, the presence of credentials is used to decide on querying either website.
 
@@ -468,6 +506,8 @@ CONTENT        Flag to indicate that the raw content of
                output folder
 CSS            Path to custom CSS file for the EPUBs   
 EMAIL          Login email for J-Novel Club account
+USE_OTP        Flag to use OTP authentication instead
+               of password (JNC Main only)
 ...
 ```
 

--- a/jncep/cli/options.py
+++ b/jncep/cli/options.py
@@ -41,6 +41,14 @@ password_nina_option = credentials_group.option(
     help="Login password for JNC Nina account",
 )
 
+otp_option = credentials_group.option(
+    "--otp",
+    "use_otp",
+    is_flag=True,
+    envvar=f"{ENVVAR_PREFIX}USE_OTP",
+    help="Use OTP (One-Time Password) authentication instead of password (JNC Main only)",
+)
+
 
 def credentials_options(f):
     # applied in reverse so they are visible in the help in the order below
@@ -48,6 +56,7 @@ def credentials_options(f):
         [
             login_option,
             password_option,
+            otp_option,
             login_nina_option,
             password_nina_option,
             process_credentials_options,
@@ -64,6 +73,7 @@ def process_credentials_options(f):
         # options should always be present even if no value passed
         email = kwargs.pop("email")
         password = kwargs.pop("password")
+        use_otp = kwargs.pop("use_otp", False)
         email_nina = kwargs.pop("email_nina")
         password_nina = kwargs.pop("password_nina")
 
@@ -73,10 +83,10 @@ def process_credentials_options(f):
             if not email_nina and password_nina:
                 email_nina = email
 
-            j_novel_credentials = email and password
+            j_novel_credentials = email and (password or use_otp)
             nina_credentials = email_nina and password_nina
 
-            if nina_credentials and email and not password:
+            if nina_credentials and email and not password and not use_otp:
                 # assume the email only applies to nina
                 email = None
 
@@ -85,10 +95,23 @@ def process_credentials_options(f):
                     "You must pass either J-Novel Club or JNC Nina credentials"
                 )
 
-            if bool(email) != bool(password):
-                raise click.UsageError(
-                    "You must pass both email and password for J-Novel Club account"
-                )
+            # Validate JNC Main credentials
+            if email:
+                if use_otp and password:
+                    raise click.UsageError(
+                        "Cannot use both password and OTP authentication. Use either --password or --otp."
+                    )
+                if not use_otp and not password:
+                    raise click.UsageError(
+                        "You must pass either password (--password) or use OTP (--otp) for J-Novel Club account"
+                    )
+                if use_otp:
+                    # OTP mode: only email needed (OTP is JNC Main only, not Nina)
+                    j_novel_credentials = True
+                elif not password:
+                    raise click.UsageError(
+                        "You must pass both email and password for J-Novel Club account"
+                    )
 
             if bool(email_nina) != bool(password_nina):
                 raise click.UsageError(
@@ -97,7 +120,12 @@ def process_credentials_options(f):
 
             credential_mapping = {}
             if j_novel_credentials:
-                credential_mapping[AltOrigin.JNC_MAIN] = (email, password)
+                if use_otp:
+                    # OTP mode: (email, None, True)
+                    credential_mapping[AltOrigin.JNC_MAIN] = (email, None, True)
+                else:
+                    # Password mode: (email, password)
+                    credential_mapping[AltOrigin.JNC_MAIN] = (email, password)
             if nina_credentials:
                 credential_mapping[AltOrigin.JNC_NINA] = (email_nina, password_nina)
 

--- a/jncep/config.py
+++ b/jncep/config.py
@@ -1,7 +1,9 @@
 from configparser import ConfigParser
 from io import StringIO
+import json
 import os
 from pathlib import Path
+from datetime import datetime, timezone
 
 from click import Context, get_app_dir
 
@@ -160,3 +162,5 @@ class JNCEPConfigParser(ConfigParser):
         super().__init__(default_section=TOP_SECTION, interpolation=None)
         # keys in upper case when reading (instead of default lower)
         self.optionxform = lambda x: x.upper()
+
+

--- a/jncep/core.py
+++ b/jncep/core.py
@@ -17,6 +17,7 @@ from typing import NamedTuple
 import dateutil.parser
 from dateutil.relativedelta import relativedelta
 from exceptiongroup import BaseExceptionGroup
+import httpx
 import trio
 
 from . import epub, jncalts, jncapi, jncweb, namegen_utils, spec, utils
@@ -128,7 +129,16 @@ class JNCEPSession:
         self.config = config
 
         self.api = jncapi.JNC_API(config)
-        self.email, self.password = credentials.get_credentials(config.ORIGIN)
+        creds = credentials.get_credentials(config.ORIGIN)
+        self.email = creds[0]
+        if len(creds) == 3 and creds[2] is True:
+            # OTP mode
+            self.password = None
+            self.use_otp = True
+        else:
+            # Password mode
+            self.password = creds[1]
+            self.use_otp = False
 
         self.now = datetime.now(tz=timezone.utc)
         # TODO only the member level is sufficient
@@ -142,7 +152,15 @@ class JNCEPSession:
         if session_dict is None:
             session_dict = {}
         if self.config.ORIGIN not in session_dict:
-            await self.login(self.email, self.password)
+            if self.use_otp:
+                # OTP is only available for JNC Main
+                if self.config.ORIGIN != jncalts.AltOrigin.JNC_MAIN:
+                    raise Exception(
+                        "OTP authentication is only available for JNC Main, not JNC Nina"
+                    )
+                await self.login_with_otp()
+            else:
+                await self.login(self.email, self.password)
             session_dict[self.config.ORIGIN] = self
             _GLOBAL_SESSION_INSTANCE.set(session_dict)
         return session_dict[self.config.ORIGIN]
@@ -195,6 +213,146 @@ class JNCEPSession:
         )
         console.status("...")
         return token
+
+    async def login_with_otp(self):
+        """Login using OTP authentication flow."""
+        import random
+
+        display_email = self.email
+        if is_debug():
+            # hide for privacy in case the trace is copied to GH issue tracker
+            display_email = re.sub(
+                r"(?<=.)(.*)(?=@)", lambda x: "*" * len(x.group(1)), self.email
+            )
+            display_email = re.sub(
+                r"(?<=@.)(.*)(?=\.)", lambda x: "*" * len(x.group(1)), display_email
+            )
+
+        # Generate OTP
+        try:
+            console.status("Generating OTP code...")
+            otp_data = await self.api.generate_otp()
+            otp_code = otp_data["otp"]
+            proof = otp_data["proof"]
+            ttl = otp_data["ttl"]
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == 429:
+                console.error("Rate limit exceeded. Please wait a moment and try again.")
+            else:
+                console.error(f"Failed to generate OTP code: {e}")
+            raise
+        except Exception as e:
+            console.error(f"Failed to generate OTP code: {e}")
+            raise
+
+        # Display OTP code to user
+        console.info("")
+        console.info(
+            f"Visit [highlight]https://j-novel.club/user/otp[/] and enter the code:"
+        )
+        console.info(f"[highlight]{otp_code}[/]")
+        console.info("")
+
+        # Poll for verification
+        start_time = time.time()
+        poll_interval = 4.0  # seconds
+        backoff_count = 0
+        max_backoff = 16.0
+        otp_cleaned_up = False
+
+        try:
+            while True:
+                elapsed = time.time() - start_time
+                remaining = max(0, ttl - elapsed)
+
+                if remaining <= 0:
+                    console.error("OTP code expired. Please generate a new code.")
+                    break
+
+                # Update status message
+                status_msg = f"Waiting for verification... ({int(remaining)} seconds remaining)"
+                console.status(status_msg)
+
+                try:
+                    # Check OTP status
+                    token_data = await self.api.check_otp(otp_code, proof)
+
+                    if token_data is not None:
+                        # OTP verified!
+                        self.api.token = token_data["id"]
+
+                        # to be able to check subscription status
+                        self.me = await self.api.me()
+                        self.member_status = member_status(self)
+
+                        emoji = ""
+                        if console.is_advanced():
+                            emoji = "\u26a1 "
+                        console.info(
+                            f"{emoji}Logged in to {self.config.ORIGIN} with email "
+                            + f"'[highlight]{display_email}[/]'"
+                        )
+                        console.status("...")
+
+                        # Optional cleanup
+                        try:
+                            await self.api.delete_otp(otp_code, proof)
+                            otp_cleaned_up = True
+                        except Exception:
+                            pass  # Silently ignore cleanup errors
+
+                        return token_data["id"]
+
+                    # Not verified yet, continue polling
+                    backoff_count = 0  # Reset backoff on successful check
+
+                except httpx.HTTPStatusError as e:
+                    if e.response.status_code == 429:
+                        # Rate limited - exponential backoff
+                        backoff_count += 1
+                        if backoff_count == 1:
+                            wait_time = 2.0
+                        elif backoff_count == 2:
+                            wait_time = 4.0
+                        elif backoff_count == 3:
+                            wait_time = 8.0
+                        else:
+                            wait_time = max_backoff
+
+                        console.warning(
+                            f"Rate limit exceeded. Waiting {int(wait_time)} seconds..."
+                        )
+                        await trio.sleep(wait_time)
+                        continue
+                    else:
+                        # Other HTTP error
+                        console.error(f"Verification failed: {e}")
+                        raise
+
+                # Add small jitter to avoid synchronized polling
+                jitter = random.uniform(-0.5, 0.5)
+                await trio.sleep(poll_interval + jitter)
+
+        except KeyboardInterrupt:
+            # User cancelled - attempt cleanup
+            console.info("\nCancelling...")
+            if not otp_cleaned_up:
+                try:
+                    await self.api.delete_otp(otp_code, proof)
+                except Exception:
+                    pass  # Silently ignore cleanup errors
+            raise
+
+        finally:
+            # Cleanup on timeout
+            if not otp_cleaned_up:
+                try:
+                    await self.api.delete_otp(otp_code, proof)
+                except Exception:
+                    pass  # Silently ignore cleanup errors
+
+        # If we get here, timeout occurred
+        raise Exception("OTP verification timed out")
 
     async def logout(self):
         if self.api.is_logged_in:

--- a/jncep/jncalts.py
+++ b/jncep/jncalts.py
@@ -26,6 +26,7 @@ class AltConfig:
     CDN_IMG_URL_BASE = attr.ib()
 
     WEB_URL_BASE = attr.ib()
+    OTP_API_URL_BASE = attr.ib(default=None)
 
 
 JNC_MAIN_CONFIG = AltConfig(
@@ -40,6 +41,7 @@ JNC_MAIN_CONFIG = AltConfig(
         "https://d2dq7ifhe7bu0f.cloudfront.net",
     ],
     WEB_URL_BASE="https://j-novel.club",
+    OTP_API_URL_BASE="https://labs.j-novel.club",
 )
 
 # after main Labs API v2 update October 2024 => properties very similar to Nina API
@@ -51,6 +53,7 @@ JNC_NINA_CONFIG = AltConfig(
     EMBED_PATH_BASE="/embed/v2",
     CDN_IMG_URL_BASE="https://cdn.jnc-nina.eu",
     WEB_URL_BASE="https://jnc-nina.eu",
+    OTP_API_URL_BASE="https://labs.j-novel.club",  # OTP endpoints might use main API even for Nina
 )
 
 
@@ -66,15 +69,26 @@ class AltOriginError(Exception):
 
 @attr.s
 class AltCredentials:
-    # contains mapping : origin => tuple (email, pw)
+    # contains mapping : origin => tuple (email, pw) or (email, None, use_otp=True)
+    # For password: (email, password)
+    # For OTP: (email, None, True) or similar structure
     credential_mapping: dict = attr.ib()
 
     def get_credentials(self, origin: AltOrigin):
-        # just the login, pw tuple
+        # returns tuple: (email, password) for password auth
+        # or (email, None, True) for OTP auth
         if credentials := self.credential_mapping.get(origin):
             return credentials
 
         raise AltOriginError(f"No credential for: {origin}")
+    
+    def uses_otp(self, origin: AltOrigin):
+        """Check if credentials for this origin use OTP authentication."""
+        if credentials := self.credential_mapping.get(origin):
+            # If tuple has 3 elements and third is True, it's OTP
+            # Otherwise it's password auth
+            return len(credentials) == 3 and credentials[2] is True
+        return False
 
     def origins_with_credentials(self):
         return list(self.credential_mapping.keys())

--- a/jncep/jncapi.py
+++ b/jncep/jncapi.py
@@ -135,6 +135,7 @@ class JNC_API:
             headers=API_COMMON_HEADERS,
             timeout=timeout,
             event_hooks=hooks,
+            follow_redirects=True,  # Enable redirect following for OTP endpoints
         )
 
         # full URL always provided (CDN) so no need for base location parameter
@@ -165,6 +166,136 @@ class JNC_API:
 
         data = r.json()
         self.token = data["id"]
+
+    async def generate_otp(self):
+        """Generate an OTP code for authentication.
+
+        Returns:
+            dict: {"otp": str, "proof": str, "ttl": int}
+
+        Raises:
+            httpx.HTTPStatusError: If request fails (including 429 rate limiting)
+        """
+        # Use the working v2 endpoint with GET method as primary
+        path = f"{self.config.API_PATH_BASE}/auth/otp4app/generate"
+        params = {**API_COMMON_PARAMS}
+
+        # Try GET first (working method), fall back to POST if needed
+        for method in ['get', 'post']:
+            try:
+                logger.debug(f"Attempting {method.upper()} to {path}")
+                if method == 'post':
+                    r = await self.api_session.post(path, params=params)
+                else:
+                    r = await self.api_session.get(path, params=params)
+
+                logger.debug(f"Response status: {r.status_code}")
+                if r.status_code < 400:  # Success or redirect
+                    r.raise_for_status()
+                    data = r.json()
+                    logger.debug("OTP generated successfully")
+                    return {"otp": data["otp"], "proof": data["proof"], "ttl": data["ttl"]}
+
+            except httpx.HTTPStatusError as e:
+                logger.debug(f"{method.upper()} to {path} failed: {e.response.status_code}")
+                if e.response.status_code not in [404, 405]:  # Not method/path not found
+                    raise
+                # Continue to try next method
+            except Exception as e:
+                logger.debug(f"{method.upper()} request failed: {e}")
+                continue
+
+        # If we get here, both methods failed
+        raise Exception("OTP generation failed - both GET and POST methods were unsuccessful")
+
+        # Try POST first (as documented), fall back to GET if needed
+        try:
+            r = await self.api_session.post(path, params=params)
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == 405:  # Method Not Allowed
+                # Try GET if POST failed
+                logger.debug("POST failed with 405, trying GET")
+                r = await self.api_session.get(path, params=params)
+            else:
+                raise
+        
+        if r.status_code == 429:
+            # Rate limited - raise with user-friendly message
+            raise httpx.HTTPStatusError(
+                "Rate limit exceeded. Please wait a moment and try again.",
+                request=r.request,
+                response=r,
+            )
+        
+        r.raise_for_status()
+        data = r.json()
+        # Security: Never log OTP code or proof token
+        logger.debug("OTP generated successfully")
+        logger.debug(f"OTP TTL: {data.get('ttl', 'unknown')}")
+        return {"otp": data["otp"], "proof": data["proof"], "ttl": data["ttl"]}
+
+    async def check_otp(self, otp, proof):
+        """Check OTP verification status.
+
+        Args:
+            otp: The OTP code (6 characters)
+            proof: The proof token from generate_otp()
+
+        Returns:
+            dict|None: Token dict if verified (200), None if not verified yet (204)
+
+        Raises:
+            httpx.HTTPStatusError: If request fails (including 429 rate limiting)
+        """
+        # OTP check endpoint uses the /app/v2 prefix like the generate endpoint
+        path = f"{self.config.API_PATH_BASE}/auth/otp4app/check/{otp}/{proof}"
+        params = {**API_COMMON_PARAMS}
+
+        r = await self.api_session.get(path, params=params)
+        
+        if r.status_code == 429:
+            # Rate limited - raise so caller can implement exponential backoff
+            raise httpx.HTTPStatusError(
+                "Rate limit exceeded. Please wait a moment and try again.",
+                request=r.request,
+                response=r,
+            )
+        
+        if r.status_code == 204:
+            # OTP exists but not verified yet
+            logger.debug("OTP check: not verified yet")
+            return None
+        
+        r.raise_for_status()
+        
+        if r.status_code == 200:
+            # OTP verified, return token
+            data = r.json()
+            logger.debug("OTP verified successfully")
+            return data
+        
+        # Unexpected status code
+        r.raise_for_status()
+
+    async def delete_otp(self, otp, proof):
+        """Delete/cancel an OTP code (cleanup).
+
+        Args:
+            otp: The OTP code
+            proof: The proof token from generate_otp()
+
+        Note: Errors are silently ignored as per API design.
+        """
+        # OTP delete endpoint uses the /app/v2 prefix like the generate endpoint
+        path = f"{self.config.API_PATH_BASE}/auth/otp4app/check/{otp}/{proof}"
+        params = {**API_COMMON_PARAMS}
+
+        try:
+            r = await self.api_session.delete(path, params=params)
+            logger.debug("OTP cleanup attempted")
+        except Exception:
+            # Silently ignore errors as per API design
+            logger.debug("OTP cleanup failed (silently ignored)")
 
     async def logout(self):
         path = f"{self.config.API_PATH_BASE}/auth/logout"


### PR DESCRIPTION
Since OTP is available through j-novel, I wanted to use it to authenticate instead of passwords, which I'm personally trying to phase out as much as possible. While this might not be useful to those who run jobs, I thought I might share this with others who prefer to avoid passwords, like me.

With this feature, you can use the --otp flag to start the authentication process, add it to your config or as an environment variable. I only implemented it for the main j-novel, since I don't have a Nina account to test with.

This is my first pull request ever, and this is all vibe coding, so no worries if this doesn't work out!

Thanks!